### PR TITLE
Add basic LangChain example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# langchain
+# LangChain Example
+
+This repository contains a simple script that uses [LangChain](https://python.langchain.com) with OpenAI's Chat models.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set your OpenAI API key:
+   ```bash
+   export OPENAI_API_KEY="your-key"
+   ```
+
+## Usage
+
+Run the example script:
+
+```bash
+python app.py
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,16 @@
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+from langchain.chains import LLMChain
+
+
+def main() -> None:
+    """Generate a simple joke using LangChain's ChatOpenAI."""
+    prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}.")
+    llm = ChatOpenAI(temperature=0)
+    chain = LLMChain(prompt=prompt, llm=llm)
+    topic = "penguins"
+    print(chain.run(topic))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+langchain
+openai


### PR DESCRIPTION
## Summary
- Add `app.py` demonstrating a simple LangChain chain using OpenAI's chat model
- Document setup and usage in README
- Include `requirements.txt` with needed dependencies

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_68a42f3a222c832395662219eb86bd95